### PR TITLE
Add clippy directive to ex08 (fixes #22)

### DIFF
--- a/exercises/08_nested_repetition/main.rs
+++ b/exercises/08_nested_repetition/main.rs
@@ -8,6 +8,7 @@ fn print_vec<V: std::fmt::Debug>(vec: &Vec<V>) {
 
 ////////// DO NOT CHANGE BELOW HERE /////////
 
+#[allow(clippy::vec_init_then_push)]
 fn main() {
     let my_graph = graph!(
         1 -> (2, 3, 4, 5);


### PR DESCRIPTION
Adding the clippy directive above `main` in the given code (already provided in the solution code) fixes the linter errors with pushing to a newly created `vec`.