### PR TITLE
Remove unneeded type notation in ex09 sum expansion

### DIFF
--- a/exercises/09_ambiguity_and_ordering/main.rs
+++ b/exercises/09_ambiguity_and_ordering/main.rs
@@ -25,7 +25,7 @@ impl NumberType {
 // Sum together at least two expressions.
 macro_rules! sum {
     ($($expr:expr),+ , $lastexpr:expr) => {
-        $($expr:expr + )+ $lastexpr
+        $($expr + )+ $lastexpr
     }
 }
 


### PR DESCRIPTION
I believe the `:expr` in the expansion of exercise 9's `sum` macro is unnecessary - and will insert the string ` : expr` into the expansion (where it is unneeded, and will cause errors).