### PR TITLE
Add missing clippy directive to ex09

### DIFF
--- a/exercises/09_ambiguity_and_ordering/main.rs
+++ b/exercises/09_ambiguity_and_ordering/main.rs
@@ -53,6 +53,7 @@ fn main() {
     get_number_type!(-5).show();
 
     // UnknownBecauseBlock
+    #[allow(clippy::let_and_return)]
     get_number_type!({
         let x = 6;
         x


### PR DESCRIPTION
The starter code for ex09 is missing a clippy directive which is present in the solutions, leading to unnecessary linter warnings.