### PR TITLE
`Debug` constraint required in print functions

### DIFF
--- a/exercises/10_macros_calling_macros/main.rs
+++ b/exercises/10_macros_calling_macros/main.rs
@@ -1,10 +1,11 @@
 ////////// DO NOT CHANGE BELOW HERE /////////
 use std::collections::HashMap;
+use std::fmt::Debug;
 
-fn print_pair<K, V>(pair: (K, V)) {
+fn print_pair<K: Debug, V: Debug>(pair: (K, V)) {
     println!("{pair:#?}");
 }
-fn print_hashmap<K, V>(hashmap: &HashMap<K, V>) {
+fn print_hashmap<K: Debug, V: Debug>(hashmap: &HashMap<K, V>) {
     println!("{hashmap:#?}");
 }
 ////////// DO NOT CHANGE ABOVE HERE /////////


### PR DESCRIPTION
`Debug` constraint is required for `K`, `V` in functions `print_pair`, `print_hashmap`  because code like:
```rust
println!("{some_variable:#?}");
```
requires `some_variable` to implement `Debug` trait.

Without this change, there is Compile Error.