### PR TITLE
Add explicit example of $crate metavariable in use

### DIFF
--- a/exercises/12_hygienic_macros/README.md
+++ b/exercises/12_hygienic_macros/README.md
@@ -1,11 +1,41 @@
 # Hygeine
 
-By default, all identifiers referred to in a macro are expanded as-is, and are
-looked up at the macro's invocation site. This can lead to issues if a macro
-refers to an item or macro which isn't in scope at the invocation site. To
-alleviate this, the `$crate` metavariable can be used at the start of a path to
-force lookup to occur inside the crate defining the macro.
+To quote [the reference](https://doc.rust-lang.org/reference/macros-by-example.html#hygiene):
 
+> By default, all identifiers referred to in a macro are expanded as-is, and are
+> looked up at the macro's invocation site. This can lead to issues if a macro
+> refers to an item or macro which isn't in scope at the invocation site. To
+> alleviate this, the `$crate` metavariable can be used at the start of a path to
+> force lookup to occur inside the crate defining the macro.
+
+Here is an example to illustrate (again, taken from the reference linked above):
+
+```rust
+// Definitions in the `helper_macro` crate.
+
+#[macro_export]
+macro_rules! helped {
+    /*
+    () => { helper!() }
+            ^^^^^^ This might lead to an error due to 'helper' not being in scope.
+    */
+    () => { $crate::helper!() }
+}
+
+#[macro_export]
+macro_rules! helper {
+    () => { () }
+}
+
+// Usage in another crate.
+// Note that `helper_macro::helper` is not imported!
+
+use helper_macro::helped;
+
+fn unit() {
+    helped!();
+}
+```
 
 ## Disclaimer
 


### PR DESCRIPTION
Another improvement I saw fit to add here is an example of how the `$crate` metavariable works exactly in chapter 12. It is quite simple when you realise what's going on, but I think having the example at hand without having to go look for it in the docs would be nice, especially when other chapters have been more self-contained wrt. examples.

The example is taken from the docs where the original text under the "Hygiene" header is taken from (which is also now has a link to the docs to make it clear where it's coming from). If you think there's a better example, then by all means: you almost certainly know better than I do here.