### PR TITLE
fix type inconsistency between exercise 10 and its solution

### DIFF
--- a/exercises/10_macros_calling_macros/main.rs
+++ b/exercises/10_macros_calling_macros/main.rs
@@ -17,7 +17,7 @@ fn print_hashmap<K: Debug, V: Debug>(hashmap: &HashMap<K, V>) {
 ////////// DO NOT CHANGE BELOW HERE /////////
 
 fn main() {
-    let pair = pair!('a' => 1);
+    let pair: (char, u8) = pair!('a' => 1);
 
     print_pair(pair);
 


### PR DESCRIPTION
Currently exercise 10's main function starts as:

```rust
fn main() {
    let pair = pair!('a' => 1);
```

After implementing `pair!`, this expands to
```rust
fn main() {
    let pair = ('a', 1);
```

However, the sample solution is typed such that it expands to
```rust
fn main() {
    let pair: (char, u8) = ('a', 1);
```

This PR just adds the types to the exercise, so that it matches the sample solution.