### PR TITLE
Fix Exercise 11 Not Requring Recursion

### DIFF
--- a/exercises/11_macro_recursion/README.md
+++ b/exercises/11_macro_recursion/README.md
@@ -62,8 +62,13 @@ A good example of this is a curried `add` function. In regular Rust, we'd say `a
 What this means is that we can write `let add_1 = add(1);`, and we now have a function
 which will add 1 to anything.
 
-In this exercise, you will build a macro which creates a curried function.
-The syntax for this function will be `curry!((a: i32) => (b: i32) => _, {a + b})`.
-Each pair of `ident: ty` is an argument, and the last `_` indicates that the
-compiler will infer the return type. The block provided last is, of course,
-the computation we want to do after receiving all the arguments.
+In this exercise, you will build a macro which helps you understand currying,
+and build a curried function in Rust. The syntax for this macro will be
+`curry!((a: i32) => (b: i32) => _, {a + b})`. Each pair of `ident: ty` is an
+argument, and the last `_` indicates that the compiler will infer the return
+type. The block provided last is, of course, the computation we want to do after
+receiving all the arguments.
+
+Each step of the currying process, you should call the macro `print_curried_argument`.
+This should print out the value that you have been provided as an argument.
+

--- a/exercises/11_macro_recursion/main.rs
+++ b/exercises/11_macro_recursion/main.rs
@@ -3,14 +3,19 @@
 ////////// DO NOT CHANGE BELOW HERE /////////
 
 fn print_numbers(nums: &Vec<i32>) {
-    println!("{nums:#?}");
+    println!("Resulting Numbers: {nums:#?}");
 }
 
 fn get_example_vec() -> Vec<i32> {
     vec![1, 3, 5, 6, 7, 9]
 }
 
+fn print_curried_argument(val: impl std::fmt::Debug) {
+    println!("Currying value {:?}.", val);
+}
+
 fn main() {
+    println!("=== defining functions ===");
     let is_between = curry!((min: i32) => (max: i32) => (item: &i32) => _, {
         min < *item && *item < max
     });
@@ -20,14 +25,18 @@ fn main() {
         vec.iter().filter_map(|i| if filter_between(i) { Some(*i) } else { None }).collect()
     });
 
+    println!("=== create between_3_7 ===");
     let between_3_7 = curry_filter_between(3)(7);
+    println!("=== create between_5_10 ===");
     let between_5_10 = curry_filter_between(5)(10);
 
     let my_vec = get_example_vec();
 
+    println!("=== call between_3_7 ===");
     let some_numbers: Vec<i32> = between_3_7(&my_vec);
     print_numbers(&some_numbers);
 
+    println!("=== call between_5_10 ===");
     let more_numbers: Vec<i32> = between_5_10(&my_vec);
     print_numbers(&more_numbers);
 }

--- a/exercises/11_macro_recursion/solutions/main.rs
+++ b/exercises/11_macro_recursion/solutions/main.rs
@@ -1,21 +1,29 @@
 macro_rules! curry {
     (_, $block:block) => {$block};
     (($argident:ident : $argtype:ty) => $(($argidents:ident: $argtypes:ty) =>)* _, $block:block) => {
-        move |$argident: $argtype| curry!($(($argidents: $argtypes) =>)* _, $block)
+        move |$argident: $argtype| {
+            print_curried_argument($argident);
+            curry!($(($argidents: $argtypes) =>)* _, $block)
+        }
     };
 }
 
 ////////// DO NOT CHANGE BELOW HERE /////////
 
 fn print_numbers(nums: &Vec<i32>) {
-    println!("{nums:#?}");
+    println!("Resulting Numbers: {nums:#?}");
 }
 
 fn get_example_vec() -> Vec<i32> {
     vec![1, 3, 5, 6, 7, 9]
 }
 
+fn print_curried_argument(val: impl std::fmt::Debug) {
+    println!("Currying value {:?}.", val);
+}
+
 fn main() {
+    println!("=== defining functions ===");
     let is_between = curry!((min: i32) => (max: i32) => (item: &i32) => _, {
         min < *item && *item < max
     });
@@ -25,14 +33,18 @@ fn main() {
         vec.iter().filter_map(|i| if filter_between(i) { Some(*i) } else { None }).collect()
     });
 
+    println!("=== create between_3_7 ===");
     let between_3_7 = curry_filter_between(3)(7);
+    println!("=== create between_5_10 ===");
     let between_5_10 = curry_filter_between(5)(10);
 
     let my_vec = get_example_vec();
 
+    println!("=== call between_3_7 ===");
     let some_numbers: Vec<i32> = between_3_7(&my_vec);
     print_numbers(&some_numbers);
 
+    println!("=== call between_5_10 ===");
     let more_numbers: Vec<i32> = between_5_10(&my_vec);
     print_numbers(&more_numbers);
 }

--- a/exercises/11_macro_recursion/solutions/solution.diff
+++ b/exercises/11_macro_recursion/solutions/solution.diff
@@ -1,9 +1,12 @@
-@@ -1,4 +1,9 @@
+@@ -1,4 +1,12 @@
 -// TODO: Create the `curry!()` macro.
 +macro_rules! curry {
 +    (_, $block:block) => {$block};
 +    (($argident:ident : $argtype:ty) => $(($argidents:ident: $argtypes:ty) =>)* _, $block:block) => {
-+        move |$argident: $argtype| curry!($(($argidents: $argtypes) =>)* _, $block)
++        move |$argident: $argtype| {
++            print_curried_argument($argident);
++            curry!($(($argidents: $argtypes) =>)* _, $block)
++        }
 +    };
 +}
  

--- a/src/update_diff.rs
+++ b/src/update_diff.rs
@@ -35,7 +35,7 @@ pub fn update_diff(exercise: &str) -> Result<(), Box<dyn Error>> {
         UnifiedDiffBuilder::new(&input),
     );
 
-    let mut file = File::create(&exercise_diff_path)?;
+    let mut file = File::create(exercise_diff_path)?;
     file.write_all(actual_diff.as_bytes())?;
 
     Ok(())


### PR DESCRIPTION
**(EXERCISE 11 SPOILERS BELOW)**

Exercise 11 didn't actually require recursion. The intended solution had braces around the recursive call:

```rust
macro_rules! curry {
    (_, $block:block) => {$block};
    (($argident:ident : $argtype:ty) => $(($argidents:ident: $argtypes:ty) =>)* _, $block:block) => {
        move |$argident: $argtype| {
            curry!($(($argidents: $argtypes) =>)* _, $block)
        }
    };
}
```

But in its old form it was possible to complete by doing something like this:
```rust
macro_rules! curry {
    (_, $block:block) => {$block};
    ($(($argidents:ident: $argtypes:ty) =>)+ _, $block:block) => {
        $(move |$argidents: $argtypes|)+ $block
    };
}
```

The change made just asks the developer to call a function (`print_curried_argument`) before doing the recursive macro call. This forces them to use braces; which in turn forces them to use recursion.