### PR TITLE
only display error message

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -21,8 +21,8 @@ pub fn test(exercise: String) -> Result<(), Box<dyn Error>> {
         .output()
         .unwrap();
 
-    let stderr_is_empty = main_output.stderr.is_empty();
-    if !stderr_is_empty || !main_output.status.success() {
+    let contains_error = String::from_utf8_lossy(&main_output.stderr).contains("error");
+    if contains_error || !main_output.status.success() {
         println!("Got some errors when expanding the macro:");
         println!();
         io::stderr().write_all(&main_output.stderr)?;


### PR DESCRIPTION
After I finished each exercise, always get
```rust
Got some errors when expanding the macro:

    Checking macrokata v0.3.1 (/home/my_path/macrokata)
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s

```
but actually there is no error, so maybe just check if there are some real error message in stderr