### PR TITLE
Doesn't checks for stderr, but only status code

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -21,8 +21,7 @@ pub fn test(exercise: String) -> Result<(), Box<dyn Error>> {
         .output()
         .unwrap();
 
-    let stderr_is_empty = main_output.stderr.is_empty();
-    if !stderr_is_empty || !main_output.status.success() {
+    if !main_output.status.success() {
         println!("Got some errors when expanding the macro:");
         println!();
         io::stderr().write_all(&main_output.stderr)?;


### PR DESCRIPTION
Solves: https://github.com/tfpk/macrokata/issues/47

If the return code is nonzero then print the error output, otherwise proceed with comparison of macro expansions. 