### PR TITLE
show 'cargo-expand' errors when testing an exercise

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -38,6 +38,12 @@ pub fn test(exercise: String) -> Result<(), Box<dyn Error>> {
         .output()
         .unwrap();
 
+    if !&main_output.status.success() {
+        println!("macrokata has encountered the following errors when attempting to expand an exercise.");
+        io::stderr().write_all(&main_output.stderr)?;
+        return Err("macrokata could not expand macros".into());
+    }
+
     println!();
     println!("This is the expansion you produced:");
     println!();


### PR DESCRIPTION
Hey, I started going through the repo, It seems this is gonna be a great way for me to learn about macros!

When I tried to run the testing for the first exercise, the diff output was empty. I tried to deliberately fail the exercise but the diff was still empty, and  I got a success result printed. Some debugging later it seems I skipped the "install cargo-expand" instruction in the readme. This PR just checks that the expand command ran successfully before printing results.

Steps to reproduce the problem:
- uninstall cargo-expand
- test exercise 1
The diff should be empty, both when expecting success and both when expecting failure.