### PR TITLE
Add allow unused to the ambiguity and ordering exercise

### DIFF
--- a/exercises/09_ambiguity_and_ordering/main.rs
+++ b/exercises/09_ambiguity_and_ordering/main.rs
@@ -3,6 +3,7 @@
 /// This enum should represent what code the user wrote exactly.
 /// Even though to a compiled program there's no difference,
 /// this will let the program tell what sort of code the user wrote.
+#[allow(unused)]
 #[derive(Debug)]
 enum NumberType {
     /// The user wrote a literal, positive number.


### PR DESCRIPTION
The 09_ambiguity_and_ordering exercise does not compile on a vanilla rust install of version cargo 1.91.1 (ea2d97820 2025-10-10) due to  unused fields warnings in the NumberType enum.

Allowing unused solves the issue.

Thanks for a fun kata!